### PR TITLE
Show selected location and restrict search to cities

### DIFF
--- a/src/app/api/geocode/route.ts
+++ b/src/app/api/geocode/route.ts
@@ -22,11 +22,18 @@ export async function GET(req: NextRequest) {
     next: { revalidate },
   });
   if (!res.ok) return Response.json({ results: [] }, { status: 200 });
-  const data = (await res.json()) as Array<{ display_name: string; lat: string; lon: string }>;
-  const results = data.map((d) => ({
-    name: d.display_name as string,
-    lat: Number(d.lat),
-    lon: Number(d.lon),
-  }));
+  const data = (await res.json()) as Array<{
+    display_name: string;
+    lat: string;
+    lon: string;
+    addresstype?: string;
+  }>;
+  const results = data
+    .filter((d) => d.addresstype === "city")
+    .map((d) => ({
+      name: d.display_name as string,
+      lat: Number(d.lat),
+      lon: Number(d.lon),
+    }));
   return Response.json({ results });
 }

--- a/src/app/api/reverse-geocode/route.ts
+++ b/src/app/api/reverse-geocode/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from "next/server";
+
+export const runtime = 'edge';
+
+export const revalidate = 86400; // cache for 1 day
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const lat = searchParams.get("lat");
+  const lon = searchParams.get("lon");
+  if (!lat || !lon) {
+    return Response.json({ name: null }, { status: 400 });
+  }
+  const url = new URL("https://nominatim.openstreetmap.org/reverse");
+  url.searchParams.set("format", "jsonv2");
+  url.searchParams.set("lat", lat);
+  url.searchParams.set("lon", lon);
+  url.searchParams.set("zoom", "10");
+  url.searchParams.set("addressdetails", "1");
+  const res = await fetch(url.toString(), {
+    headers: {
+      "User-Agent": "was-today-weird/0.1 (+https://example.com)",
+      "Accept-Language": "en",
+    },
+    next: { revalidate },
+  });
+  if (!res.ok) return Response.json({ name: null }, { status: 200 });
+  const data = await res.json();
+  const name =
+    data?.address?.city ||
+    data?.address?.town ||
+    data?.address?.village ||
+    data?.name ||
+    data?.display_name ||
+    null;
+  return Response.json({ name });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,7 @@ export default async function Home({ searchParams }: { searchParams?: Promise<Re
   // Derive location: query params -> IP geo -> fallback to Vadodara
   let lat = Number(spObj?.lat);
   let lon = Number(spObj?.lon);
+  let locationName = spObj?.loc;
   const base = process.env.NEXT_PUBLIC_BASE_URL || (await getBaseUrl());
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
     try {
@@ -45,11 +46,15 @@ export default async function Home({ searchParams }: { searchParams?: Promise<Re
         lat = geo.lat;
         lon = geo.lon;
       }
+      if (!locationName && geo?.city) {
+        locationName = geo.city as string;
+      }
     } catch {}
   }
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
     lat = 22.3072; // Vadodara fallback
     lon = 73.1812;
+    if (!locationName) locationName = "Vadodara";
   }
   const today = new Date();
   const doy = dayOfYear(today);
@@ -85,7 +90,14 @@ export default async function Home({ searchParams }: { searchParams?: Promise<Re
     <div className="min-h-screen p-6 flex flex-col items-center gap-8">
       <header className="w-full max-w-3xl flex items-center justify-between">
         <h1 className="text-xl font-semibold">Was today weird?</h1>
-        <div className="text-sm text-gray-500">{forecast.day} • {forecast.tz}</div>
+        <div className="flex items-center gap-2">
+          <div className="text-sm text-gray-500">{forecast.day} • {forecast.tz}</div>
+          {locationName && (
+            <span className="px-2 py-1 rounded-full text-xs bg-gray-100 dark:bg-zinc-800 text-gray-700 dark:text-gray-200">
+              {locationName}
+            </span>
+          )}
+        </div>
       </header>
       <LocationSearch />
       <main className="w-full max-w-3xl flex flex-col gap-6">


### PR DESCRIPTION
## Summary
- display selected location name as chip in header
- add reverse geocoding and handle geolocation denial gracefully
- limit geocode results to cities only

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac834c61d883329693307bc1a8e07a