### PR TITLE
fix: avoid 204 with body in geo route

### DIFF
--- a/src/app/api/geo/route.ts
+++ b/src/app/api/geo/route.ts
@@ -48,6 +48,9 @@ export async function GET(req: NextRequest) {
     }
   } catch {}
 
-  return Response.json({ error: "geo unavailable" }, { status: 204 });
+  // Return an explicit error response instead of using a 204 status code,
+  // which does not allow a response body. Using 503 (Service Unavailable)
+  // communicates the failure while still allowing a JSON payload.
+  return Response.json({ error: "geo unavailable" }, { status: 503 });
 }
 


### PR DESCRIPTION
## Summary
- return 503 error for geo endpoint instead of 204 with body
- explain why 204 is invalid with body

## Testing
- `pnpm lint`
- `curl -i http://localhost:3000/api/geo`

------
https://chatgpt.com/codex/tasks/task_e_68ac890a9dd08332852bc7efaef8edb0