### PR TITLE
Add air quality API and summary component

### DIFF
--- a/src/app/api/airquality/route.ts
+++ b/src/app/api/airquality/route.ts
@@ -1,0 +1,63 @@
+export const runtime = 'edge';
+
+import { NextRequest } from "next/server";
+
+export const revalidate = 1800; // 30 minutes
+
+type OMairResponse = {
+  hourly?: {
+    time: string[];
+    pm2_5?: number[];
+    pm10?: number[];
+    ozone?: number[];
+    nitrogen_dioxide?: number[];
+    sulphur_dioxide?: number[];
+    us_aqi?: number[];
+  };
+};
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const lat = Number(searchParams.get("lat"));
+  const lon = Number(searchParams.get("lon"));
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return Response.json({ error: "lat and lon are required" }, { status: 400 });
+  }
+
+  const params = new URLSearchParams({
+    latitude: String(lat),
+    longitude: String(lon),
+    hourly: [
+      "pm2_5",
+      "pm10",
+      "ozone",
+      "nitrogen_dioxide",
+      "sulphur_dioxide",
+      "us_aqi",
+    ].join(","),
+    timezone: "auto",
+  });
+
+  const url = `https://air-quality-api.open-meteo.com/v1/air-quality?${params.toString()}`;
+  const res = await fetch(url, { next: { revalidate } });
+  if (!res.ok) {
+    return Response.json({ error: "upstream error", status: res.status }, { status: 502 });
+  }
+  const data = (await res.json()) as OMairResponse;
+
+  const t = data.hourly?.time;
+  const idx = t && t.length > 0 ? t.length - 1 : -1;
+  const out = {
+    ts: idx >= 0 && t ? t[idx] : undefined,
+    pm2_5: data.hourly?.pm2_5?.[idx],
+    pm10: data.hourly?.pm10?.[idx],
+    ozone: data.hourly?.ozone?.[idx],
+    nitrogen_dioxide: data.hourly?.nitrogen_dioxide?.[idx],
+    sulphur_dioxide: data.hourly?.sulphur_dioxide?.[idx],
+    us_aqi: data.hourly?.us_aqi?.[idx],
+  };
+
+  return Response.json(out);
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,8 @@ import UpcomingAnomalyChart from "@/components/UpcomingAnomalyChart";
 import { percentileOf } from "@/lib/stats";
 import ChartCard from "@/components/ChartCard";
 import LocationSearch from "@/components/LocationSearch";
+import AirQualitySummary from "@/components/AirQualitySummary";
+import { AirQuality } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -58,14 +60,17 @@ export default async function Home({ searchParams }: { searchParams?: Promise<Re
   }
   const today = new Date();
   const doy = dayOfYear(today);
-  const [forecast, normals] = await Promise.all([
-    fetch(new URL(`/api/forecast?lat=${lat}&lon=${lon}`, base), { cache: "no-store" }).then(
-      (r) => r.json() as Promise<ForecastOut>
-    ),
-    fetch(new URL(`/api/normals?lat=${lat}&lon=${lon}&doy=${doy}`, base)).then(
-      (r) => r.json() as Promise<NormalsOut>
-    ),
-  ]);
+    const [forecast, normals, air] = await Promise.all([
+      fetch(new URL(`/api/forecast?lat=${lat}&lon=${lon}`, base), { cache: "no-store" }).then(
+        (r) => r.json() as Promise<ForecastOut>
+      ),
+      fetch(new URL(`/api/normals?lat=${lat}&lon=${lon}&doy=${doy}`, base)).then(
+        (r) => r.json() as Promise<NormalsOut>
+      ),
+      fetch(new URL(`/api/airquality?lat=${lat}&lon=${lon}`, base)).then(
+        (r) => r.json() as Promise<AirQuality>
+      ),
+    ]);
 
   const tActual = forecast.daily.t_mean_c;
   const tNormal = normals.daily.t_mean_c_mean;
@@ -100,8 +105,9 @@ export default async function Home({ searchParams }: { searchParams?: Promise<Re
         </div>
       </header>
       <LocationSearch />
-      <main className="w-full max-w-3xl flex flex-col gap-6">
-        <section className="rounded-2xl border border-black/10 dark:border-white/10 p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <main className="w-full max-w-3xl flex flex-col gap-6">
+          <AirQualitySummary data={air} />
+          <section className="rounded-2xl border border-black/10 dark:border-white/10 p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="flex flex-col gap-2">
             <div className="text-sm text-gray-600">Temperature anomaly</div>
             <div className="text-5xl font-bold">{fmtDelta(delta, "°C")}</div>

--- a/src/components/AirQualitySummary.tsx
+++ b/src/components/AirQualitySummary.tsx
@@ -1,0 +1,40 @@
+import { AirQuality } from "@/lib/types";
+
+function aqiLabel(aqi: number): string {
+  if (aqi <= 50) return "Good";
+  if (aqi <= 100) return "Moderate";
+  if (aqi <= 150) return "Unhealthy for Sensitive";
+  if (aqi <= 200) return "Unhealthy";
+  if (aqi <= 300) return "Very Unhealthy";
+  return "Hazardous";
+}
+
+function fmt(n: unknown): string {
+  return typeof n === "number" && Number.isFinite(n) ? n.toFixed(1) : "–";
+}
+
+export default function AirQualitySummary({ data }: { data: AirQuality }) {
+  const aqi = data.us_aqi;
+  const details = [
+    typeof data.pm2_5 === "number" ? `PM2.5 ${fmt(data.pm2_5)}` : null,
+    typeof data.pm10 === "number" ? `PM10 ${fmt(data.pm10)}` : null,
+    typeof data.ozone === "number" ? `O₃ ${fmt(data.ozone)}` : null,
+  ].filter(Boolean);
+
+  return (
+    <section className="rounded-2xl border border-black/10 dark:border-white/10 p-4 flex flex-col gap-2">
+      <div className="text-sm text-gray-600">Air quality</div>
+      {typeof aqi === "number" && Number.isFinite(aqi) ? (
+        <div className="text-xl font-semibold">
+          AQI {aqi.toFixed(0)} • {aqiLabel(aqi)}
+        </div>
+      ) : (
+        <div className="text-xl font-semibold">Air quality data unavailable</div>
+      )}
+      {details.length > 0 && (
+        <div className="text-sm text-gray-600">{details.join(" • ")} µg/m³</div>
+      )}
+    </section>
+  );
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,3 +31,13 @@ export type TodayResult = {
   source: { today: "forecast"; yesterday: "reanalysis" | "forecast" };
 };
 
+export type AirQuality = {
+  ts?: string;
+  us_aqi?: number;
+  pm2_5?: number;
+  pm10?: number;
+  ozone?: number;
+  nitrogen_dioxide?: number;
+  sulphur_dioxide?: number;
+};
+


### PR DESCRIPTION
## Summary
- fetch air quality data from Open-Meteo and expose via `/api/airquality`
- define `AirQuality` type and summary component for AQI and pollutant levels
- show current air quality on the home page alongside weather data

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a8fd6408332911f83cd08dc06f2