### PR TITLE
Expand geocode settlements

### DIFF
--- a/src/components/LocationSearch.tsx
+++ b/src/components/LocationSearch.tsx
@@ -90,7 +90,7 @@ export default function LocationSearch() {
             setQ(e.target.value);
             setOpen(true);
           }}
-          placeholder="Search city"
+          placeholder="Search city, town, or village"
           className="w-full px-3 py-2 rounded-md border border-black/10 dark:border-white/10 bg-white/70 dark:bg-zinc-900/50 backdrop-blur text-sm outline-none focus:ring-2 focus:ring-blue-500"
         />
         {open && (results.length > 0 || loading) && (
@@ -98,9 +98,9 @@ export default function LocationSearch() {
             {loading && (
               <div className="px-3 py-2 text-xs text-gray-500">Searching…</div>
             )}
-            {results.map((r, i) => (
+            {results.map((r) => (
               <button
-                key={`${r.lat},${r.lon}-${i}`}
+                key={`${r.lat},${r.lon}`}
                 className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-zinc-800"
                 onClick={() => applyLocation(r.lat, r.lon, r.name)}
               >

--- a/src/lib/api/geocode.ts
+++ b/src/lib/api/geocode.ts
@@ -35,8 +35,16 @@ export async function geocodeSearch(query: string): Promise<GeocodeResponse> {
       addresstype?: string;
     }>;
 
+    const settlementTypes = new Set(["city", "town", "village"]);
+    const seen = new Set<string>();
     const results = data
-      .filter((d) => d.addresstype === "city")
+      .filter((d) => settlementTypes.has(d.addresstype ?? ""))
+      .filter((d) => {
+        const key = `${d.lat},${d.lon}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
       .map((d) => ({
         name: d.display_name as string,
         lat: Number(d.lat),


### PR DESCRIPTION
## Summary
- broaden geocode filter to include towns and villages and dedupe results
- update location search placeholder and use unique keys

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9608c16c8332ab193a02faf9ddcf