### PR TITLE
feat: cache weather API results in session

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses Open‑Meteo APIs and Recharts for charts.
 
+## Caching
+
+Forecast and normals requests are cached for the duration of the browser session.
+Results are stored in `sessionStorage` when available and fall back to an in-memory map.
+Subsequent calls to `getForecast` or `getNormals` with the same arguments reuse cached
+data. Pass `forceRefresh: true` as the last argument to either function to bypass the
+cache and fetch fresh data.
+
 ## Learn More
 
 To learn more about Next.js, see the official docs: https://nextjs.org/docs

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,8 +1,14 @@
 // Main API utilities for client-side data fetching
 // All external API calls (Open-Meteo, Nominatim) are made directly from the browser
 
-export { getForecast, type ForecastResult } from "./forecast";
-export { getNormals, type NormalsResult } from "./normals";
+import {
+  getForecast as fetchForecast,
+  type ForecastResult,
+} from "./forecast";
+import {
+  getNormals as fetchNormals,
+  type NormalsResult,
+} from "./normals";
 export {
   geocodeSearch,
   type GeocodeResult,
@@ -17,9 +23,67 @@ export {
   type GeoError,
 } from "./geo";
 
-// Import types for internal use
-import type { ForecastResult } from "./forecast";
-import type { NormalsResult } from "./normals";
+// Simple session cache for forecast and normals
+const memoryCache = new Map<string, unknown>();
+
+function readCache<T>(key: string): T | undefined {
+  if (typeof window !== "undefined") {
+    try {
+      const raw = window.sessionStorage.getItem(key);
+      if (raw) {
+        return JSON.parse(raw) as T;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  return memoryCache.get(key) as T | undefined;
+}
+
+function writeCache<T>(key: string, value: T) {
+  memoryCache.set(key, value);
+  if (typeof window !== "undefined") {
+    try {
+      window.sessionStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export async function getForecast(
+  lat: number,
+  lon: number,
+  date?: string,
+  forceRefresh = false
+): Promise<ForecastResult> {
+  const key = `forecast:${lat}:${lon}:${date ?? ""}`;
+  if (!forceRefresh) {
+    const cached = readCache<ForecastResult>(key);
+    if (cached) return cached;
+  }
+  const result = await fetchForecast(lat, lon, date);
+  writeCache(key, result);
+  return result;
+}
+
+export async function getNormals(
+  lat: number,
+  lon: number,
+  doy: number,
+  forceRefresh = false
+): Promise<NormalsResult> {
+  const key = `normals:${lat}:${lon}:${doy}`;
+  if (!forceRefresh) {
+    const cached = readCache<NormalsResult>(key);
+    if (cached) return cached;
+  }
+  const result = await fetchNormals(lat, lon, doy);
+  writeCache(key, result);
+  return result;
+}
+
+export type { ForecastResult, NormalsResult };
 
 // Re-export commonly used types for convenience
 export type WeatherData = {


### PR DESCRIPTION
## Summary
- add simple session/in-memory cache for forecast and normals API calls
- allow bypassing cache with optional `forceRefresh` flag
- document API caching behavior in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac9614f6148332867a9cc311ad8021