### PR TITLE
Add about page and site explainer

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function AboutPage() {
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">How it works</h1>
+      <p>
+        Was today weird compares today’s temperature and wind with the
+        1991–2020 climate normals for your location. It uses Open‑Meteo
+        forecast and reanalysis data to calculate anomalies, percentiles,
+        and z‑scores.
+      </p>
+      <p>
+        For each day, the app fetches normal values for the same day of the
+        year and contrasts them with the latest observation or forecast to
+        show how unusual the conditions are.
+      </p>
+      <p>
+        <Link href="/" className="underline">
+          Back to home
+        </Link>
+      </p>
+    </div>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/api";
 import { useEffect, useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 
 function MainContent() {
   const searchParams = useSearchParams();
@@ -92,6 +93,10 @@ function MainContent() {
             <div className="w-20 h-6 bg-gray-200 dark:bg-zinc-700 rounded-full animate-pulse"></div>
           </div>
         </header>
+
+        <div className="w-full max-w-3xl text-center">
+          <div className="w-64 h-4 bg-gray-200 dark:bg-zinc-700 rounded mx-auto animate-pulse"></div>
+        </div>
 
         {/* LocationSearch skeleton */}
         <div className="flex items-center gap-2 w-full max-w-3xl">
@@ -214,6 +219,13 @@ function MainContent() {
           )}
         </div>
       </header>
+      <p className="text-sm text-gray-600 text-center">
+        Compares today’s weather with 1991–2020 normals.{' '}
+        <Link href="/about" className="underline">
+          How it works
+        </Link>
+        .
+      </p>
       <LocationSearch />
       <main className="w-full max-w-3xl flex flex-col gap-6">
         <section className="rounded-2xl border border-black/10 dark:border-white/10 p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -302,6 +314,10 @@ function LoadingSkeleton() {
           <div className="w-20 h-6 bg-gray-200 dark:bg-zinc-700 rounded-full animate-pulse"></div>
         </div>
       </header>
+
+      <div className="w-full max-w-3xl text-center">
+        <div className="w-64 h-4 bg-gray-200 dark:bg-zinc-700 rounded mx-auto animate-pulse"></div>
+      </div>
 
       {/* LocationSearch skeleton */}
       <div className="flex items-center gap-2 w-full max-w-3xl">


### PR DESCRIPTION
## Summary
- Add brief explainer on homepage that links to details
- Introduce `/about` page describing data sources and anomaly calculations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad352344008332bb588d839140853b